### PR TITLE
Bucket should be quoted in query string

### DIFF
--- a/dalmatinerdb/query_builder.js
+++ b/dalmatinerdb/query_builder.js
@@ -26,7 +26,7 @@ function () {
       throw "Metric is missing";
     }
 
-    var src = q.metric + " BUCKET " + q.bucket;
+    var src = q.metric + " BUCKET '" + q.bucket + "'";
     if (q.mget_enabled && q.mget && q.mget !== 'none') {
       src = q.mget + "(" + src + ")";
     }


### PR DESCRIPTION
Otherwise query will fail for bucket names starting with digit.
